### PR TITLE
Add CPU-based skylight SH coefficients

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@
 * Iris - version 1.5 and above
 * OptiFine - on Minecraft 1.16.5 and above
 * Photon is also compatible with [Distant Horizons](https://www.curseforge.com/minecraft/mc-mods/distant-horizons) (as of writing this requires a special version of Iris and Distant Horizons which is available in the Iris installer)
+## precomputing skylight SH
+Photon now expects spherical-harmonic coefficients for skylight as a uniform.
+Use `scripts/generate_skylight_sh.py` to compute these coefficients from a sky map and upload them to the `u_sky_sh` uniform before rendering.
+Define `SKY_SH_LEGACY` to revert to the old in-shader sampling path.
+
 
 ## showcase videos
 

--- a/scripts/generate_skylight_sh.py
+++ b/scripts/generate_skylight_sh.py
@@ -1,0 +1,88 @@
+import math
+import sys
+
+import numpy as np
+from PIL import Image
+
+
+def sh_coeff_order_2(direction):
+    x, y, z = direction
+    return np.array([
+        0.2820947918,
+        0.4886025119 * x,
+        0.4886025119 * z,
+        0.4886025119 * y,
+        1.0925484310 * x * y,
+        1.0925484310 * y * z,
+        0.3153915653 * (3.0 * z * z - 1.0),
+        0.7725484040 * x * z,
+        0.3862742020 * (x * x - y * y),
+    ], dtype=np.float32)
+
+
+def project_sky(direction):
+    projected_dir = direction[:2] / np.linalg.norm(direction[:2])
+    azimuth_angle = math.pi + math.atan2(projected_dir[0], -projected_dir[1])
+    altitude_angle = math.pi / 2.0 - math.acos(direction[1])
+
+    coord_x = azimuth_angle * (1.0 / (2.0 * math.pi))
+    coord_y = 0.5 + 0.5 * math.copysign(1.0, altitude_angle) * math.sqrt(
+        2.0 / math.pi * abs(altitude_angle)
+    )
+
+    pad_amount = 2.0
+    mul = 1.0 - 2.0 * pad_amount / 191.0
+    add = pad_amount / 191.0
+    coord_x = coord_x * mul + add
+    coord_x *= 191.0 / 192.0
+
+    return np.array([coord_x, coord_y])
+
+
+def load_sky(path):
+    img = Image.open(path).convert("RGB")
+    return np.array(img, dtype=np.float32) / 255.0
+
+
+def sample_sky(tex, coord):
+    h, w, _ = tex.shape
+    x = int(coord[0] * w) % w
+    y = max(min(int(coord[1] * h), h - 1), 0)
+    return tex[y, x]
+
+
+def compute_sh(tex, step_count=256):
+    sh = np.zeros((9, 3), dtype=np.float64)
+    for i in range(step_count):
+        u = (i + 0.5) / step_count
+        v = (i * 0.5 + 0.5) / step_count
+        phi = 2.0 * math.pi * u
+        cos_theta = 1.0 - 2.0 * v
+        sin_theta = math.sqrt(1.0 - cos_theta * cos_theta)
+        direction = np.array([
+            math.cos(phi) * sin_theta,
+            cos_theta,
+            math.sin(phi) * sin_theta,
+        ])
+
+        radiance = sample_sky(tex, project_sky(direction))
+        coeff = sh_coeff_order_2(direction)
+        for band in range(9):
+            sh[band] += radiance * coeff[band]
+
+    step_solid_angle = 2.0 * math.pi / step_count
+    return (sh * step_solid_angle).astype(np.float32)
+
+
+def main(path):
+    tex = load_sky(path)
+    sh = compute_sh(tex)
+    for band in range(9):
+        print("vec3({:.6f}, {:.6f}, {:.6f})".format(*sh[band]))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python3 generate_skylight_sh.py <sky_image>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/shaders/program/d4_deferred_shading.vsh
+++ b/shaders/program/d4_deferred_shading.vsh
@@ -64,6 +64,8 @@ uniform float time_noon;
 uniform float time_sunset;
 uniform float time_midnight;
 
+uniform vec3 u_sky_sh[9];
+
 // ------------
 //   Includes
 // ------------
@@ -93,24 +95,30 @@ void main() {
 	moon_color   = get_moon_exposure() * get_moon_tint();
 	float skylight_boost = get_skylight_boost();
 
-	#ifdef SH_SKYLIGHT
-	// Initialize SH to 0
-	for (uint band = 0; band < 9; ++band) sky_sh[band] = vec3(0.0);
+       #ifdef SH_SKYLIGHT
+       #ifndef SKY_SH_LEGACY
+       for (uint band = 0; band < 9; ++band) {
+               sky_sh[band] = u_sky_sh[band];
+       }
+       #else
+       // Initialize SH to 0
+       for (uint band = 0; band < 9; ++band) sky_sh[band] = vec3(0.0);
 
-	// Sample into SH
-	const uint step_count = 256;
-	for (uint i = 0; i < step_count; ++i) {
-		vec3 direction = uniform_hemisphere_sample(vec3(0.0, 1.0, 0.0), r2(int(i)));
-		vec3 radiance  = texture(colortex4, project_sky(direction)).rgb;
-		float[9] coeff = sh_coeff_order_2(direction);
+       // Sample into SH
+       const uint step_count = 256;
+       for (uint i = 0; i < step_count; ++i) {
+               vec3 direction = uniform_hemisphere_sample(vec3(0.0, 1.0, 0.0), r2(int(i)));
+               vec3 radiance  = texture(colortex4, project_sky(direction)).rgb;
+               float[9] coeff = sh_coeff_order_2(direction);
 
-		for (uint band = 0; band < 9; ++band) sky_sh[band] += radiance * coeff[band];
-	}
+               for (uint band = 0; band < 9; ++band) sky_sh[band] += radiance * coeff[band];
+       }
 
-	// Apply skylight boost and normalize SH
-	const float step_solid_angle = tau / float(step_count);
-	for (uint band = 0; band < 9; ++band) sky_sh[band] *= skylight_boost * step_solid_angle;
-	#else
+       // Apply skylight boost and normalize SH
+       const float step_solid_angle = tau / float(step_count);
+       for (uint band = 0; band < 9; ++band) sky_sh[band] *= skylight_boost * step_solid_angle;
+       #endif
+       #else
 	vec3 dir0 = normalize(vec3(0.0, 1.0, -0.8));               // Up
 	vec3 dir1 = normalize(vec3(sun_dir.xz + 0.1, 0.066).xzy);  // Sun-facing horizon
 	vec3 dir2 = normalize(vec3(moon_dir.xz + 0.1, 0.066).xzy); // Opposite horizon


### PR DESCRIPTION
## Summary
- let the deferred shading vertex shader accept precomputed skylight SH
- keep the previous in-shader loop behind `SKY_SH_LEGACY`
- provide a Python script that generates SH coefficients from a sky map
- document the new uniform in the README

## Testing
- `python3 -m py_compile scripts/generate_skylight_sh.py`

------
https://chatgpt.com/codex/tasks/task_e_683f83f1b278832b8f2c976e696e5e8a