### PR TITLE
Add early exit for negligible transmittance

### DIFF
--- a/shaders/include/fog/air_fog_vl.glsl
+++ b/shaders/include/fog/air_fog_vl.glsl
@@ -95,7 +95,7 @@ mat2x3 raymarch_air_fog(vec3 world_start_pos, vec3 world_end_pos, bool sky, floa
 	mat2x3 light_sun = mat2x3(0.0); // Rayleigh, mie
 	mat2x3 light_sky = mat2x3(0.0); // Rayleigh, mie
 
-	for (int i = 0; i < step_count; ++i, world_pos += world_step, shadow_pos += shadow_step) {
+        for (int i = 0; i < step_count; ++i, world_pos += world_step, shadow_pos += shadow_step) {
 		vec3 shadow_screen_pos = distort_shadow_space(shadow_pos) * 0.5 + 0.5;
 
 #if defined SHADOW && !defined PROGRAM_DEFERRED0
@@ -132,8 +132,10 @@ mat2x3 raymarch_air_fog(vec3 world_start_pos, vec3 world_end_pos, bool sky, floa
 		light_sky[0] += visible_scattering * density.x;
 		light_sky[1] += visible_scattering * density.y;
 
-		transmittance *= step_transmittance;
-	}
+                transmittance *= step_transmittance;
+
+                if (max_of(transmittance) < 0.01) break;
+        }
 
 	light_sun[0] *= air_fog_coeff[0][0];
 	light_sun[1] *= air_fog_coeff[0][1];

--- a/shaders/include/fog/end_fog_vl.glsl
+++ b/shaders/include/fog/end_fog_vl.glsl
@@ -154,8 +154,10 @@ mat2x3 raymarch_end_fog(
 		scattering += 4.0 * end_fog_emission(world_pos) * step_length * transmittance;
 #endif
 
-		transmittance *= step_transmittance;
-	}
+                transmittance *= step_transmittance;
+
+                if (max_of(transmittance) < 0.01) break;
+        }
 
 	scattering *= scattering_coeff;
 	transmittance = pow(transmittance, vec3(0.75));

--- a/shaders/include/fog/water_fog_vl.glsl
+++ b/shaders/include/fog/water_fog_vl.glsl
@@ -109,8 +109,10 @@ mat2x3 raymarch_water_fog(
 			sky_transmittance = sqrt(sky_transmittance);
 		}
 
-		transmittance *= step_transmittance;
-	}
+                transmittance *= step_transmittance;
+
+                if (max_of(transmittance) < 0.01) break;
+        }
 
 	scattering *= (1.0 - step_transmittance) * scattering_coeff / extinction_coeff;
 	transmittance = pow(transmittance, vec3(0.75));

--- a/shaders/include/sky/blocky_clouds.glsl
+++ b/shaders/include/sky/blocky_clouds.glsl
@@ -222,8 +222,7 @@ vec4 raymarch_blocky_clouds(
 	//   Raymarching Loop
 	// --------------------
 
-	for (uint i = 0u; i < primary_steps; ++i, world_pos += world_step) {
-		if (transmittance < min_transmittance) break;
+        for (uint i = 0u; i < primary_steps; ++i, world_pos += world_step) {
 
 		float altitude_fraction = (world_pos.y - layer_altitude) * rcp(blocky_clouds_thickness);
 
@@ -247,7 +246,9 @@ vec4 raymarch_blocky_clouds(
 			bounced_light
 		) * transmittance * mix(0.8, 1.25, cubic_smooth(altitude_fraction));
 
-		transmittance *= step_transmittance;
+                transmittance *= step_transmittance;
+
+                if (transmittance < 0.01) break;
 
 		// Update distance to cloud
 		float distance_to_sample = distance(cameraPosition, world_pos);

--- a/shaders/include/sky/clouds/altocumulus.glsl
+++ b/shaders/include/sky/clouds/altocumulus.glsl
@@ -205,8 +205,7 @@ CloudsResult draw_altocumulus_clouds(
 	//   Raymarching Loop
 	// --------------------
 
-	for (uint i = 0u; i < primary_steps; ++i) {
-		if (transmittance < min_transmittance) break;
+        for (uint i = 0u; i < primary_steps; ++i) {
 
 		vec3 ray_pos = ray_origin + ray_step * i;
 
@@ -247,7 +246,9 @@ CloudsResult draw_altocumulus_clouds(
 			bounced_light
 		) * transmittance;
 
-		transmittance *= step_transmittance;
+                transmittance *= step_transmittance;
+
+                if (transmittance < 0.01) break;
 
 		// Update distance to cloud
 		distance_sum += distance_to_sample * density;

--- a/shaders/include/sky/clouds/cumulus.glsl
+++ b/shaders/include/sky/clouds/cumulus.glsl
@@ -224,8 +224,7 @@ CloudsResult draw_cumulus_clouds(
 	//   Raymarching Loop
 	// --------------------
 
-	for (uint i = 0u; i < primary_steps; ++i) {
-		if (transmittance < min_transmittance) break;
+        for (uint i = 0u; i < primary_steps; ++i) {
 
 		vec3 ray_pos = ray_origin + ray_step * i;
 
@@ -267,7 +266,9 @@ CloudsResult draw_cumulus_clouds(
 			bounced_light
 		) * transmittance;
 
-		transmittance *= step_transmittance;
+                transmittance *= step_transmittance;
+
+                if (transmittance < 0.01) break;
 
 		// Update distance to cloud
 		distance_sum += distance_to_sample * density;

--- a/shaders/include/sky/clouds/cumulus_congestus.glsl
+++ b/shaders/include/sky/clouds/cumulus_congestus.glsl
@@ -190,8 +190,7 @@ CloudsResult draw_cumulus_congestus_clouds(
 	//   Raymarching Loop
 	// --------------------
 
-	for (uint i = 0u; i < primary_steps; ++i) {
-		if (transmittance < min_transmittance) break;
+        for (uint i = 0u; i < primary_steps; ++i) {
 
 		vec3 ray_pos = ray_origin + ray_step * i;
 
@@ -226,7 +225,9 @@ CloudsResult draw_cumulus_congestus_clouds(
 			bounced_light
 		) * transmittance;
 
-		transmittance *= step_transmittance;
+                transmittance *= step_transmittance;
+
+                if (transmittance < 0.01) break;
 
 		// Update distance to cloud
 		distance_sum += distance_to_sample * density;


### PR DESCRIPTION
## Summary
- monitor transmittance during fog and cloud raymarching
- exit loops once transmittance drops below `0.01`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407cf0d69c832b85c5058c2749099a